### PR TITLE
Fixed the sudo PATH for t_functional

### DIFF
--- a/vagrant_test.sh
+++ b/vagrant_test.sh
@@ -9,7 +9,7 @@ echo 'Updates due :' ${UpdtPkgs}
 #    echo 'More than 10 packages due an update!'
 #    exit 1
 #else
-    vagrant ssh -c "cd sync; sudo ./runtests.sh "
+    vagrant ssh -c 'cd sync; sudo env "PATH=$PATH" ./runtests.sh'
     # the $? check here isnt going to work since it will be the ssh exit, not the
     # script exit 
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
tested on a local vagrant box, and seems to work for the p_which test that was failing due to incorrect $PATH
